### PR TITLE
docs: link the download/install path from the guide

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -9,6 +9,11 @@ what a specific API does. You do not need any Swift experience to follow the
 tutorial or how-to guide; the reference section assumes you are reading the
 Swift source.
 
+Not installed yet? [Download MacDirStat](https://ti-03.github.io/MacDirStat/)
+from the project page, or build it from source by cloning the
+[repository](https://github.com/Ti-03/MacDirStat) and opening
+`MacDirStat.xcodeproj` in Xcode.
+
 - New to MacDirStat? Start with the [tutorial](tutorial/first-scan.md).
 - Trying to make sense of the colors in the chart? Read
   [How to read the treemap](how-to/read-the-treemap.md).

--- a/guide/tutorial/first-scan.md
+++ b/guide/tutorial/first-scan.md
@@ -6,7 +6,9 @@ you will have scanned a real folder and seen its contents as a treemap.
 ## Before you start
 
 You need MacDirStat installed and a folder you are curious about, for
-example your Downloads folder.
+example your Downloads folder. If you have not installed it yet,
+[download MacDirStat](https://ti-03.github.io/MacDirStat/) from the project
+page first.
 
 ## 1. Open MacDirStat
 


### PR DESCRIPTION
## What
Adds download/install links to the docs guide: one on the guide home, one in the tutorial's **Before you start**.

## Why
Week 6 'empathy for the reader' exercise (read the docs as a stranger): both pages say you need MacDirStat installed, but neither links to where to get it. A reader who lands on `/guide/` directly (search, shared link) hits a dead end at step zero. The landing page has the download button, so the fix is just linking it.

## How
- `guide/index.md`: 'Not installed yet?' paragraph pointing at the project page and the build-from-source path.
- `guide/tutorial/first-scan.md`: install link in **Before you start**.

## Test
`mkdocs build --strict` passes locally; links point at the existing landing page.