### PR TITLE
security: least-privilege CI token + SECURITY.md (Scorecard fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: build-and-test only reads the repo. Without this block
+# the job gets the default token, which can write contents.
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: Build & Test (${{ matrix.os }})

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| 1.1.x   | Yes       |
+| < 1.1   | No        |
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security problems.
+
+Report vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/Ti-03/MacDirStat/security/advisories/new)
+("Report a vulnerability" on the repo's Security tab). That keeps the report
+confidential while a fix is prepared.
+
+What to include:
+
+- What the issue is and where (file, function, or behavior).
+- Steps to reproduce, or a proof of concept.
+- What an attacker gains (impact).
+
+What to expect:
+
+- An acknowledgment within 7 days.
+- A fix or a status update within 30 days for confirmed issues.
+- Credit in the release notes if you want it.
+
+MacDirStat is a local, on-device app: it never sends data off the machine, so
+most issues in scope are local ones (unsafe file operations, privilege
+mistakes, malicious folder contents crashing or confusing the scanner).


### PR DESCRIPTION
## What
- `ci.yml`: top-level `permissions: contents: read` (least privilege).
- `SECURITY.md`: private reporting via GitHub Security Advisories, supported versions, response expectations.

## Why
Week 7, task 4: ran OpenSSF Scorecard on this repo, aggregate **3.0/10**. Of the twelve zero-score checks, most need process or settings changes (branch protection, code review, fuzzing). The two fixable by PR are **Token-Permissions** (workflows get a default token that can write contents; the 2024 tj-actions incident shows why that matters) and **Security-Policy** (no private reporting path existed).

Related: #12 fixes two more zero-score checks (Dependency-Update-Tool via Dependabot, Pinned-Dependencies via SHA pins).

## Test
`scorecard --repo=github.com/Ti-03/MacDirStat` re-run after merge should move Token-Permissions and Security-Policy off 0.