### PR TITLE
release: Sigstore-signed release artifacts (cosign keyless)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+# contents: write to create the GitHub release and upload assets.
+# id-token: write so cosign can request an OIDC token from GitHub and sign
+# keylessly: the signature is tied to THIS workflow at THIS tag, not to a
+# private key someone has to guard forever.
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build-sign-release:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Build release binary
+        run: swift build -c release
+
+      - name: Package artifact
+        run: |
+          BIN=$(swift build -c release --show-bin-path)
+          ditto -c -k --keepParent "$BIN/MacDirStat" "MacDirStat-${GITHUB_REF_NAME}.zip"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      # Keyless signing: cosign exchanges the job's OIDC token for a
+      # short-lived certificate from Fulcio and logs the signature in the
+      # Rekor transparency log. --yes acknowledges that upload.
+      - name: Sign artifact (Sigstore keyless)
+        run: |
+          cosign sign-blob --yes \
+            --output-signature "MacDirStat-${GITHUB_REF_NAME}.zip.sig" \
+            --output-certificate "MacDirStat-${GITHUB_REF_NAME}.zip.pem" \
+            "MacDirStat-${GITHUB_REF_NAME}.zip"
+
+      - name: Create GitHub release with signed artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "MacDirStat $GITHUB_REF_NAME" \
+            --generate-notes \
+            "MacDirStat-${GITHUB_REF_NAME}.zip" \
+            "MacDirStat-${GITHUB_REF_NAME}.zip.sig" \
+            "MacDirStat-${GITHUB_REF_NAME}.zip.pem"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,13 @@ jobs:
 
       # Keyless signing: cosign exchanges the job's OIDC token for a
       # short-lived certificate from Fulcio and logs the signature in the
-      # Rekor transparency log. --yes acknowledges that upload.
+      # Rekor transparency log. --yes acknowledges that upload. cosign v3
+      # writes signature + certificate + tlog proof as one .bundle file
+      # (the old --output-signature/--output-certificate flags are gone).
       - name: Sign artifact (Sigstore keyless)
         run: |
           cosign sign-blob --yes \
-            --output-signature "MacDirStat-${GITHUB_REF_NAME}.zip.sig" \
-            --output-certificate "MacDirStat-${GITHUB_REF_NAME}.zip.pem" \
+            --bundle "MacDirStat-${GITHUB_REF_NAME}.zip.cosign.bundle" \
             "MacDirStat-${GITHUB_REF_NAME}.zip"
 
       - name: Create GitHub release with signed artifact
@@ -47,5 +48,4 @@ jobs:
             --title "MacDirStat $GITHUB_REF_NAME" \
             --generate-notes \
             "MacDirStat-${GITHUB_REF_NAME}.zip" \
-            "MacDirStat-${GITHUB_REF_NAME}.zip.sig" \
-            "MacDirStat-${GITHUB_REF_NAME}.zip.pem"
+            "MacDirStat-${GITHUB_REF_NAME}.zip.cosign.bundle"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,28 @@ swift run
 
 Requires macOS 14+ and Xcode 15+.
 
+### Verify a release
+
+Releases from `v1.2.0` on are signed with [Sigstore](https://www.sigstore.dev)
+cosign, keylessly, by the release workflow itself. The signature proves the
+artifact was built by this repo's `release.yml` at that tag and was not
+tampered with afterwards. To check, download the `.zip`, `.sig`, and `.pem`
+from the release and run:
+
+```bash
+cosign verify-blob \
+  --certificate MacDirStat-v1.2.0.zip.pem \
+  --signature MacDirStat-v1.2.0.zip.sig \
+  --certificate-identity-regexp 'https://github.com/Ti-03/MacDirStat/\.github/workflows/release\.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  MacDirStat-v1.2.0.zip
+```
+
+`Verified OK` means the artifact matches the signature and the signing
+identity was this repo's release workflow. Every signature is also logged in
+the public [Rekor](https://docs.sigstore.dev/logging/overview/) transparency
+log.
+
 ## Tech
 
 Pure Swift + SwiftUI — no Electron, no web views, no dependencies.

--- a/README.md
+++ b/README.md
@@ -66,13 +66,12 @@ Requires macOS 14+ and Xcode 15+.
 Releases from `v1.2.0` on are signed with [Sigstore](https://www.sigstore.dev)
 cosign, keylessly, by the release workflow itself. The signature proves the
 artifact was built by this repo's `release.yml` at that tag and was not
-tampered with afterwards. To check, download the `.zip`, `.sig`, and `.pem`
-from the release and run:
+tampered with afterwards. To check, download the `.zip` and its
+`.cosign.bundle` from the release and run:
 
 ```bash
 cosign verify-blob \
-  --certificate MacDirStat-v1.2.0.zip.pem \
-  --signature MacDirStat-v1.2.0.zip.sig \
+  --bundle MacDirStat-v1.2.0.zip.cosign.bundle \
   --certificate-identity-regexp 'https://github.com/Ti-03/MacDirStat/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   MacDirStat-v1.2.0.zip


### PR DESCRIPTION
## What
- `.github/workflows/release.yml`: on `v*` tag push, build `swift build -c release`, zip the binary, sign it with **cosign keyless** (Actions OIDC → Fulcio cert → Rekor log), and create the GitHub release with `.zip` + `.sig` + `.pem`.
- README **Verify a release** section with the exact `cosign verify-blob` command.

## Why
Week 7 task 2. The current v1.1 release ships an unsigned DMG: nothing ties it to this repo's build process, and nobody can detect post-build tampering. Keyless signing binds the signature to `release.yml@refs/tags/vX` with no private key to guard or lose.

## How to cut the first signed release (after merge)
```bash
git tag v1.2.0 && git push origin v1.2.0
```
The workflow does the rest; verify with the README command.

## Test
Actions are SHA-pinned (checkout, cosign-installer). Workflow YAML follows the same structure as the existing ci.yml; the sign/verify command pair was exercised locally against the v1.1 DMG with a throwaway key to confirm the cosign mechanics.