### PR TITLE
community: CONTRIBUTING, CODE_OF_CONDUCT, GOVERNANCE, templates, license notice

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-request review from the maintainer for everything.
+* @Ti-03

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Something broken, wrong, or crashing
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What happened
+
+<!-- What did you see? Screenshots of the chart help a lot. -->
+
+## What you expected
+
+## Steps to reproduce
+
+1.
+2.
+
+## Environment
+
+- macOS version:
+- MacDirStat version (About window) and source (App Store / DMG / built from source):
+- The folder you scanned: roughly how many files, and anything unusual
+  (network mount, iCloud placeholders, hardlinks, external disk):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: An idea that would make MacDirStat better
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## The problem
+
+<!-- What are you trying to do that you currently can't (or that hurts)? -->
+
+## Proposed solution
+
+<!-- If you have one. "I don't know, but the problem is real" is fine too. -->
+
+## Alternatives considered
+
+<!-- Other tools, workarounds, or approaches you've tried. -->
+
+Note the bar from [GOVERNANCE.md](../../GOVERNANCE.md): features should serve
+the core job (see where your disk space went) without adding complexity
+everyone else pays for.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What
+
+<!-- One or two sentences: what does this PR change? -->
+
+## Why
+
+<!-- The problem or issue this solves. Link the issue: Fixes #NN -->
+
+## How
+
+<!-- Anything a reviewer should know about the approach or trade-offs. -->
+
+## Test
+
+<!-- How you verified it: `swift test` output, manual steps, screenshots. -->
+
+- [ ] `swift test` passes locally
+- [ ] New behavior has a test / bug fix has the test that would have caught it

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+qutibah.an3@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to MacDirStat
+
+Thanks for considering a contribution. This page covers everything you need to
+go from clone to merged PR without having to ask.
+
+## Dev environment
+
+```bash
+git clone https://github.com/Ti-03/MacDirStat.git
+cd MacDirStat
+swift run          # builds and launches the app
+```
+
+Requires macOS 14+ and Xcode 15+. There are no third-party dependencies.
+`MacDirStat.xcodeproj` works too if you prefer Xcode to SwiftPM.
+
+## Run the tests
+
+```bash
+swift test
+```
+
+CI runs the same suite on a `macos-15` / `macos-26` matrix. One gotcha the
+matrix exists to catch: runtime `#available(macOS 26, *)` checks do NOT make
+code compile against an older SDK. Anything using a new-SDK symbol (like the
+Liquid Glass APIs) also needs a compile-time `#if compiler(>=6.2)` guard; see
+`GlassCompat.swift` and `docs/adr/0001` for the full story.
+
+Docs changes are prose-linted by Vale (Microsoft style) in CI. Run locally
+with `vale sync && vale guide docs/adr README.md`.
+
+## File a bug
+
+Use the bug report template. The three things that make a disk-scanner bug
+reproducible: your macOS version, the kind of folder you scanned (roughly how
+many files, any network mounts / iCloud placeholders / hardlinks), and what
+the chart showed versus what you expected. Screenshots help a lot.
+
+Do not report security issues in public issues; see [SECURITY.md](SECURITY.md).
+
+## PR conventions
+
+- **Issue first** for anything bigger than a bug fix or typo, so we agree on
+  the direction before you spend your evening on it.
+- Keep PRs single-purpose and reviewable in one sitting.
+- PR description follows What / Why / How / Test (the template scaffolds it).
+- `swift test` green locally before pushing; CI must be green to merge.
+- New behavior comes with a test; bug fixes come with the test that would
+  have caught the bug.
+
+## Licensing of contributions
+
+MacDirStat is AGPL-3.0, and the same app also ships on the Mac App Store
+(as DirStat), which is possible because the maintainer holds the copyright.
+By contributing you agree that your contribution is licensed under
+AGPL-3.0-only and that you grant the maintainer permission to distribute
+your contribution as part of the Mac App Store build. If you are not
+comfortable with that, say so in the PR and we will talk before merging.
+
+## Review expectations
+
+Solo maintainer. Honest service levels:
+
+- First response on a PR or issue: within a week, usually faster.
+- One-on-one debugging support is not something I can offer; a minimal
+  reproducible example in an issue is the reliable way to get my attention.
+- Features that add API or UI complexity to serve a narrow use case will
+  usually get a "no, but here is how a fork could do it" rather than a merge;
+  see [GOVERNANCE.md](GOVERNANCE.md) for how decisions are made.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,39 @@
+# Governance
+
+## The model: BDFL
+
+MacDirStat is maintained by one person, [Qutibah Ananzeh](https://github.com/Ti-03)
+(Ti-03), who has final say on every decision: what gets merged, what the
+roadmap is, when releases happen, and what the project will not do. This is
+the honest description of how a one-maintainer project works, written down
+because implicit governance is the worst kind.
+
+## How decisions are made
+
+- **Bug fixes:** if it is broken and the fix has a test, it gets merged.
+- **Features:** open an issue first. The bar is "does this serve the core
+  job (see where your disk space went) without adding complexity everyone
+  else pays for". If you disagree with a decision, file an issue and make
+  the case; decisions get reversed when the argument or the evidence is
+  better, not when it is louder.
+- **Breaking changes** to file formats, CLI behavior, or the public docs
+  structure get an ADR in `docs/adr/` before they land.
+
+## What a "no" looks like
+
+A "no" here comes with a reason and, where possible, an alternative: usually
+"maintain it as a fork, and I will link it from the README". A "not now" means
+the idea is fine but unstaffed; a PR that includes maintenance (tests, docs)
+changes that answer.
+
+## Path to shared maintainership
+
+If someone shows up with a run of quality PRs and sticks around through a few
+review cycles, commit access is on the table. If that happens, this document
+gets rewritten first: at two maintainers, "the founder decides" stops being
+governance and starts being a bottleneck.
+
+## Releases
+
+The maintainer tags releases (SemVer). From v1.2.0 they are signed with
+Sigstore cosign by the release workflow; verify per the README.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,21 @@ MacDirStat collects zero data. No network access. No analytics. No tracking. Eve
 
 ## Contributing
 
-PRs welcome. Open an issue first for anything beyond a bug fix.
+PRs welcome. Open an issue first for anything beyond a bug fix. Setup, test
+commands, PR conventions, and review expectations are in
+[CONTRIBUTING.md](CONTRIBUTING.md); how decisions get made is in
+[GOVERNANCE.md](GOVERNANCE.md).
+
+## License
+
+Copyright © 2026 Qutibah Ananzeh (Ti-03).
+
+MacDirStat is licensed under the [GNU AGPL-3.0](LICENSE): use it, read it,
+modify it, but if you distribute a modified version (or host one as a
+service), your changes must stay open under the same license. The Mac App
+Store build is distributed by the copyright holder, which is what makes the
+combination possible; see [CONTRIBUTING.md](CONTRIBUTING.md) for what that
+means for contributions.
 
 ---
 


### PR DESCRIPTION
## What
Fills the rest of GitHub's Community Standards checklist (week 9 of OpenLab): CONTRIBUTING.md, CODE_OF_CONDUCT.md (Contributor Covenant 2.1 verbatim), GOVERNANCE.md (honest BDFL), bug/feature issue templates, What/Why/How/Test PR template, CODEOWNERS, plus the README copyright line + License section the stock AGPL text lacked.

## Why
Community profile was 42% (README + LICENSE only). With SECURITY.md from #13 and these files, the checklist goes green.

## Notable
CONTRIBUTING.md carries an inbound-licensing clause: this repo is AGPL-3.0 while the same app ships on the Mac App Store, which only works while the maintainer can license every line, so contributions include an App Store distribution grant.

## Test
Docs-only change; CI matrix runs on the PR.